### PR TITLE
Meurt si la sous-classe du converter pose problème

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -572,7 +572,10 @@ biblio::
   converter;;
     Généralement laissé vide. Peut contenir le nom d'une sous-classe
     Perl spécifique de conversion des notices. Accessible uniquement à
-    un programmeur Perl.
+    un programmeur Perl. Si le champs est renseigné mais que le Chargeur
+    n'arrive pas à charger la sous-classe (à cause d'une erreur de
+    syntaxe ou parce qu'il ne trouve pas la sous-classe), le Chargeur
+    retournera une erreur et s'interrompra.
   exclure;;
     Contient la liste des champs de la notice Sudoc qu'il faut supprimer.
   proteger;;

--- a/lib/Koha/Contrib/Sudoc/Loader.pm
+++ b/lib/Koha/Contrib/Sudoc/Loader.pm
@@ -78,13 +78,12 @@ sub BUILD {
     # Instanciation du converter
     my $class = 'Koha::Contrib::Sudoc::Converter';
     if ( my $local_class = $self->sudoc->c->{biblio}->{converter} ) {
-        if ( try_load_class($local_class) ) {
+        my ($retcod, $error ) = try_load_class($local_class);
+        if ( $retcod ) {
             $class = $local_class;
         }
         else {
-            $self->log->warning(
-                "Attention : le convertisseur $local_class est introuvable dans le répertoire 'lib'. " .
-                "Le convertisseur par défaut sera utilisé.\n");
+            die $error ;
         }
     }
     load_class($class);


### PR DESCRIPTION
Si l'on définit une sous-classe de converter dans la section
chargement :

biblio:
  converter: Sous::Classe

et si le Chargeur n'arrive pas à charger cette Sous::Classe (erreur de
syntaxe, absent de @INC...), il faut que le programme renvoie une
erreur et meure plutôt que de charger le converter par défaut.