### PR TITLE
Répare les chargements de plusieurs fichiers

### DIFF
--- a/lib/Koha/Contrib/Sudoc/Spool.pm
+++ b/lib/Koha/Contrib/Sudoc/Spool.pm
@@ -117,7 +117,7 @@ sub first_batch_files {
     my $files = $self->files($where, $type);
     return $files unless @$files;
 
-    my ($prefix_first) = $files->[0] =~ /^(.*)001.RAW/;
+    my ($prefix_first) = $files->[0] =~ /^(.*)\d{3}.RAW/;
     my @first_files;
     for my $file (@$files) {
         my ($prefix) = $file =~ /^(.*)\d{3}.RAW/;


### PR DESCRIPTION
Le sudoc peut envoyer plusieurs fichiers dans le cas de très gros
chargements, typiquement après la coupure estivale :

TR323R3239A001.RAW
TR323R3239A002.RAW

Or le code ne liste que les suffixes en 001. La présence d'un fichier
avec une autre séquence provoque la mort du script :

Use of uninitialized value $prefix_first in string ne at /home/koha/util/sudoc/lib/Koha/Contrib/Sudoc/Spool.pm line 124.

Cette correction permet de charger toutes séquences de 000 à 999. Les
fichiers sont bien chargés dans l'ordre.